### PR TITLE
feat: makes netrc-file and netrc-stdin mutually exclusive.

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -36,6 +36,8 @@ func init() {
 	RootCmd.PersistentFlags().String("netrc-file", "", "Read .netrc from file location, has precedence over --netrc-stdin")
 	RootCmd.PersistentFlags().Bool("netrc-stdin", false, "Read .netrc from stdin")
 
+	RootCmd.MarkFlagsMutuallyExclusive("netrc-file", "netrc-stdin")
+
 	RootCmd.AddCommand(created.RootCmd)
 	RootCmd.AddCommand(labels.RootCmd)
 }


### PR DESCRIPTION
They shouldn't be used together as they contradict each other.